### PR TITLE
Log suggestion when having trouble getting Mac wallpaper

### DIFF
--- a/src/lib/MacWallpaper.js
+++ b/src/lib/MacWallpaper.js
@@ -7,6 +7,9 @@ function MacWallpaper() {
 
     osascript.execute('tell application "System Events" to tell every desktop to get properties', function (err, allSettings) {
         if (err) {
+            if (err.toLowerCase().indexOf('application isn’t running') > -1) {
+                log.error('Could not get current wallpapers. Try restarting System Events or restarting your computer.');
+            }
             throw new Error(err);
         }
         this.existingWallpaperSettings = allSettings;


### PR DESCRIPTION
When System Events is having a fit, applescript can fail with "Applescript fails with error (-600)". It can be resolved by restarting System Events or restarting your computer. This PR adds a message to that effect.