### PR TITLE
Add reconnect for when GPMDP closes intermittently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,6 +1540,11 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "reconnecting-websocket": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz",
+      "integrity": "sha512-SWSfoXiaHVOqXuPWFgGWeUxKnb5HIY7I/Fh5C/hy4wUOgeOh7YIMXEiv5/eHBlNs4tNzCrO5YDR9AH62NWle0Q=="
+    },
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
@@ -1919,11 +1924,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
     "url-regex": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
@@ -1997,13 +1997,11 @@
       }
     },
     "ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "1.0.0"
       }
     },
     "xhr": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "jimp": "^0.2.28",
     "node-osascript": "^2.0.0",
     "raptor-args": "^1.0.3",
+    "reconnecting-websocket": "^3.2.2",
     "request": "^2.85.0",
     "screen-info": "^1.0.1",
     "string-template": "^1.0.0",
     "time-stamp": "^2.0.0",
     "wallpaper": "^2.6.0",
-    "ws": "^4.0.0"
+    "ws": "^5.1.1"
   },
   "devDependencies": {
     "eslint": "^4.18.0"

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,13 @@ desktopPlayerEventEmitter.on(Channels.Track, (trackInfo) => {
     debouncedGenerateWallpaper(trackInfo);
 });
 
+desktopPlayerEventEmitter.connect();
+
+process.on('SIGINT', function () {
+    desktopPlayerEventEmitter.disconnect();
+    process.exit(0);
+});
+
 if (options.setWallpaper) {
     albumArtCreator.on('wallpaper-created', (path) => {
         wallpaper.set(path, (err) => {

--- a/src/lib/DesktopPlayerEventEmitter.js
+++ b/src/lib/DesktopPlayerEventEmitter.js
@@ -1,37 +1,54 @@
 const EventEmitter = require('events');
 const util = require('util');
 const WebSocket = require('ws');
+const ReconnectingWebSocket = require('reconnecting-websocket');
 const Channels = require('./Channels');
 const log = require('./Logging/logger');
+const process = require('process');
 
 function DesktopPlayer(webSocketAddress) {
     EventEmitter.call(this);
 
     this.messages = {};
+    this.webSocketAddress = webSocketAddress;
 
-    this.ws = new WebSocket(webSocketAddress);
+    this.connect = function () {
+        this.socket = new ReconnectingWebSocket(webSocketAddress, undefined, { constructor: WebSocket });
 
-    this.ws.onmessage = e => {
-        const data = JSON.parse(e.data);
-        const stringifiedPayload = JSON.stringify(data.payload);
+        this.socket.addEventListener('error', err => {
+            if (err.code === 'EHOSTDOWN') {
+                log.error('Maximum number of attempts to connect to Google Play Music Desktop Player exceeded. Check that it is open and that the JSON and Playback API are enabled.');
+                process.exit(0);
+            }
+        });
 
-        if (this.messages[data.channel] && this.messages[data.channel] === stringifiedPayload) {
-            log.debug('The same data has already been emitted on this channel recently', data.channel, data.payload);
-            return;
-        }
+        this.socket.addEventListener('message', event => {
+            const data = JSON.parse(event.data);
+            const stringifiedPayload = JSON.stringify(data.payload);
 
-        if (data.channel === Channels.Track) {
-            /* Allow rating and lyrics to be considered new if the track changes
-               Rating, specifically, can be the same between two songs and should emit an event
-               for the new song */
-            this.messages[Channels.Rating] = undefined;
-            this.messages[Channels.Lyrics] = undefined;
-        }
+            if (this.messages[data.channel] && this.messages[data.channel] === stringifiedPayload) {
+                log.debug('The same data has already been emitted on this channel recently', data.channel, data.payload);
+                return;
+            }
 
-        this.messages[data.channel] = stringifiedPayload;
+            if (data.channel === Channels.Track) {
+                /* Allow rating and lyrics to be considered new if the track changes
+                   Rating, specifically, can be the same between two songs and should emit an event
+                   for the new song */
+                this.messages[Channels.Rating] = undefined;
+                this.messages[Channels.Lyrics] = undefined;
+            }
 
-        this.emit(data.channel, data.payload);
-    };
+            this.messages[data.channel] = stringifiedPayload;
+
+            this.emit(data.channel, data.payload);
+        });
+    }.bind(this);
+
+    this.disconnect = function () {
+        const NORMAL_CLOSURE_CODE = 1000;
+        this.socket.close(NORMAL_CLOSURE_CODE, 'Closing application', { keepClosed: true });
+    }.bind(this);
 }
 
 util.inherits(DesktopPlayer, EventEmitter);


### PR DESCRIPTION
Allows running the application when Google Play Music Desktop Player is not running, or the APIs are not enabled. Also allows the application to continue running if GPMDP experiences intermittent issues with it's web socket server or if it closes and is reopened.