### PR TITLE
Assert Discog broad search result release contains artist and album

### DIFF
--- a/src/lib/AlbumArtSource/Discogs.js
+++ b/src/lib/AlbumArtSource/Discogs.js
@@ -89,7 +89,8 @@ module.exports = function (consumerKey, consumerSecret) {
                                     return cb(new Error('No album releases found on Discogs'));
                                 }
 
-                                const validReleases = getReleasesWithValidAlbumFormat(response.results);
+                                const validReleases = getReleasesWithValidAlbumFormat(getReleasesContainingAlbumInfo(response.results,
+                                    payload.artist, payload.album));
 
                                 if (validReleases.length === 0) {
                                     return cb(new Error('No album releases found on Discogs'));


### PR DESCRIPTION
Broad search was always meant to assert this in the release info, but never did.

While the image comparing still caught that album covers clearly do not match, this prevents unnecessary image fetching/consideration. 